### PR TITLE
Add layer of security around operations

### DIFF
--- a/roster/src/Roster.Web/Areas/Roster/Pages/ApplicationForm/Details.cshtml.cs
+++ b/roster/src/Roster.Web/Areas/Roster/Pages/ApplicationForm/Details.cshtml.cs
@@ -1,14 +1,17 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Roster.Core.Domain;
 using Roster.Core.Services;
 using Roster.Core.Storage;
+using Roster.Web.Security;
 using Domain = Roster.Core.Domain;
 
 namespace Roster.Web.Areas.Roster.Pages.ApplicationForm
 {
+    [Authorize(Policy = Policy.AcceptMembers)]
     public class DetailsModel : PageModel
     {
         private readonly IApplicationStorage _storage;
@@ -37,7 +40,7 @@ namespace Roster.Web.Areas.Roster.Pages.ApplicationForm
             ApplicationForm = _storage.GetByNickname(new Domain.MemberNickname(nickname));
             return Page();
         }
-
+        
         public IActionResult OnPostAccept()
         {
             _service.AcceptApplicationForm(new MemberNickname(Nickname));

--- a/roster/src/Roster.Web/Areas/Roster/Pages/ApplicationForm/ListApplications.cshtml.cs
+++ b/roster/src/Roster.Web/Areas/Roster/Pages/ApplicationForm/ListApplications.cshtml.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Roster.Core.Storage;
+using Roster.Web.Security;
 using Domain = Roster.Core.Domain;
 
 namespace Roster.Web.Areas.Roster.Pages.ApplicationForm
 {
+    [Authorize(Policy = Policy.ViewApplications)]
     public class ListApplicationsModel : PageModel
     {
         private readonly IApplicationStorage _storage;

--- a/roster/src/Roster.Web/Areas/Roster/Pages/Member/Details.cshtml.cs
+++ b/roster/src/Roster.Web/Areas/Roster/Pages/Member/Details.cshtml.cs
@@ -1,10 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Roster.Core.Storage;
+using Roster.Web.Security;
 using Domain = Roster.Core.Domain;
 
 namespace Roster.Web.Areas.Roster.Pages.Member
 {
+    [Authorize(Policy = Policy.ViewMembers)]
     public class DetailsModel : PageModel
     {
         private readonly IMemberStorage _memberStorage;

--- a/roster/src/Roster.Web/Areas/Roster/Pages/Member/List.cshtml.cs
+++ b/roster/src/Roster.Web/Areas/Roster/Pages/Member/List.cshtml.cs
@@ -1,10 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Roster.Core.Storage;
+using Roster.Web.Security;
 using Domain = Roster.Core.Domain;
 
 namespace Roster.Web.Areas.Roster.Pages.Member
 {
+    [Authorize(Policy = Policy.ViewMembers)]
     public class ListModel : PageModel
     {
         private const int PageSize = 20;

--- a/roster/src/Roster.Web/Pages/Index.cshtml
+++ b/roster/src/Roster.Web/Pages/Index.cshtml
@@ -19,9 +19,9 @@
     <div class="col-md-4">
         <h2>Members</h2>
         <ul>
-            <li>
+            @* <li>
                 <a asp-area="Roster" asp-page="/Member/Test">Test verification</a>
-            </li>
+            </li> *@
             <li>
                 <a asp-area="Roster" asp-page="/Member/List">List members</a>
             </li>

--- a/roster/src/Roster.Web/Security/Policy.cs
+++ b/roster/src/Roster.Web/Security/Policy.cs
@@ -1,0 +1,9 @@
+namespace Roster.Web.Security
+{
+    public static class Policy
+    {
+        public const string ViewApplications = "ViewApplications";
+        public const string AcceptMembers = "AcceptMembers";
+        public const string ViewMembers = "ViewMembers";
+    }
+}

--- a/roster/src/Roster.Web/Security/PolicyFactory.cs
+++ b/roster/src/Roster.Web/Security/PolicyFactory.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Roster.Web.Security
+{
+    public static class PolicyFactory
+    {
+        public static void BuildPolicies(AuthorizationOptions options)
+        {
+            options.AddPolicyByName(Policy.ViewApplications);
+            options.AddPolicyByName(Policy.AcceptMembers);
+            options.AddPolicyByName(Policy.ViewMembers);
+        }
+
+        private static void AddPolicyByName(this AuthorizationOptions authorizationOptions, string policyName)
+        {
+            authorizationOptions.AddPolicy(policyName, p => p.RequireClaim(policyName));
+        }
+    }
+}

--- a/roster/src/Roster.Web/Startup.cs
+++ b/roster/src/Roster.Web/Startup.cs
@@ -24,6 +24,7 @@ using Roster.Infrastructure.Configurations;
 using Roster.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Roster.Web.Security;
 
 namespace Roster.Web
 {
@@ -91,6 +92,8 @@ namespace Roster.Web
 
             services.AddMassTransitHostedService();
             services.AddScoped<IEventStore, EventStore>();
+
+            services.AddAuthorization(options => PolicyFactory.BuildPolicies(options));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Add layer of security around operations:
  - list applications (claim: ViewApplications)
  - accept/reject member (claim: AcceptMembers)
  - list members (claim: ViewMembers)

Remove unneeded test verification from home screen.

To test, you need to manually add claims in the **Identity** database like this:
```
insert into "AspNetUserClaims" (
	"UserId",
	"ClaimType",
	"ClaimValue"
) values (
	'1c7b5cf8-99e6-4cd4-890a-cb409fbcd0cc',
	'ViewMembers',
	''
);
```

UserId represents Id in AspNetUsers. **Roster permissions will need to be given like this until someone creates an UI.**