### PR TITLE
Force Location header to https even if incoming request uses http.

### DIFF
--- a/roster/Build-Docker.ps1
+++ b/roster/Build-Docker.ps1
@@ -1,7 +1,13 @@
+# Cleaning up
 if (Test-Path .\docker-build) {
 	Remove-Item .\docker-build -Recurse -Force
 }
 
+docker container stop cnto-roster
+docker container rm cnto-roster
+docker image rm cntoarma/roster:0.2.0-snapshot
+
+# Build new image
 dotnet publish .\src\Roster.Web --configuration Release --output .\docker-build
 Copy-Item .\container\Dockerfile .\docker-build
-docker build -t cntoarma/roster:0.2.0-rc5 -t cntoarma/roster:latest .\docker-build
+docker build -t cntoarma/roster:0.2.0-snapshot .\docker-build

--- a/roster/Start-Container.ps1
+++ b/roster/Start-Container.ps1
@@ -1,3 +1,3 @@
 docker container stop cnto-roster
 docker container rm cnto-roster
-docker run --name cnto-roster -p 80:80 -e RabbitMq__Host=host.docker.internal -e RabbitMq__Username=guest -e RabbitMq__Password=guest -e ConnectionStrings__Roster="Host=host.docker.internal;Database=roster;Username=postgres;Password=cnto_dev" -e ConnectionStrings__PostgresConnection="Host=host.docker.internal;Database=identity;Username=postgres;Password=cnto_dev" -d cntoarma/roster:latest
+docker run --name cnto-roster -p 80:80 -e RabbitMq__Host=host.docker.internal -e RabbitMq__Username=guest -e RabbitMq__Password=guest -e ConnectionStrings__Roster="Host=host.docker.internal;Database=roster;Username=postgres;Password=cnto_dev" -e ConnectionStrings__PostgresConnection="Host=host.docker.internal;Database=identity;Username=postgres;Password=cnto_dev" -d cntoarma/roster:0.2.0-snapshot

--- a/roster/container/Dockerfile
+++ b/roster/container/Dockerfile
@@ -4,6 +4,5 @@ COPY . /app
 WORKDIR /app
 
 EXPOSE 80
-EXPOSE 443
 
 ENTRYPOINT ["dotnet", "Roster.Web.dll"]


### PR DESCRIPTION
This is a dirty hack and should be removed once HAProxy starts receiving http requests. Closes #53 