### PR TITLE
Add Discord integration for member rank update

### DIFF
--- a/src/Roster.DiscordService/Configurations/DiscordOptions.cs
+++ b/src/Roster.DiscordService/Configurations/DiscordOptions.cs
@@ -1,0 +1,11 @@
+namespace Roster.DiscordService.Configurations
+{
+    public class DiscordOptions
+    {
+        public string BotToken { get; set; }
+
+        public ulong GuildId { get; set; }
+
+        public Dictionary<string, ulong> RanksMap { get; set; }
+    }
+}

--- a/src/Roster.DiscordService/DiscordService.cs
+++ b/src/Roster.DiscordService/DiscordService.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Roster.DiscordService.Configurations;
+using Discord.Rest;
+using Discord;
+
+namespace Roster.DiscordService
+{
+    public class DiscordService
+    {
+        bool _loggedIn;
+
+        readonly DiscordOptions _options;
+
+        DiscordRestClient _client;
+
+        RestGuild _guild;
+
+        readonly ILogger<DiscordService> _logger;
+
+        public DiscordService(DiscordOptions options, ILogger<DiscordService> logger)
+        {
+            _options = options;
+            _loggedIn = false;
+            _logger = logger;
+            _client = new DiscordRestClient();
+        }
+
+        public async Task Login()
+        {
+            if (!_loggedIn)
+            {
+                await _client.LoginAsync(TokenType.Bot, _options.BotToken);
+                _guild = await _client.GetGuildAsync(_options.GuildId);
+                _loggedIn = true;
+
+                _logger.LogInformation("DiscordService logged in");
+            }
+        }
+
+        public async Task Logout()
+        {
+            if (_loggedIn)
+            {
+                await _client.LogoutAsync();
+                _guild = null;
+                _loggedIn = false;
+
+                _logger.LogInformation("DiscordService logged out");
+            }
+        }
+
+        public async Task UpdateMemberRank(UpdateMemberRankCommand command)
+        {
+            await Login();
+
+            RestGuildUser member = await FindGuildMember(command.DiscordNickname);
+
+            if (command.OldRank.HasValue)
+            {
+                ulong oldDiscordRoleId = MapRosterRankId(command.OldRank);
+                await member.RemoveRoleAsync(oldDiscordRoleId);
+
+                _logger.LogInformation($"Removed role {oldDiscordRoleId} from member {command.DiscordNickname}");
+            }
+
+            ulong newDiscordRoleId = MapRosterRankId(command.NewRank);
+            await member.AddRoleAsync(newDiscordRoleId);
+
+            _logger.LogInformation($"Added role {newDiscordRoleId} to member {command.DiscordNickname}");
+
+            await Logout();
+        }
+
+        private async Task<RestGuildUser> FindGuildMember(string nickname)
+        {
+            IReadOnlyCollection<RestGuildUser> matches = await _guild.SearchUsersAsync(nickname, 1);
+
+            if (matches.Count != 1)
+            {
+                throw new ArgumentException($"Couldn't find member {nickname} in CNTO Guild");
+            }
+
+            return matches.First();
+        }
+
+        private ulong MapRosterRankId(int? rosterRank)
+        {
+            // Note: the .ToString() call is required due to the automapping from appsettings.json
+            return _options.RanksMap[rosterRank.ToString()];
+        }
+    }
+}

--- a/src/Roster.DiscordService/MemberPromotedConsumer.cs
+++ b/src/Roster.DiscordService/MemberPromotedConsumer.cs
@@ -1,0 +1,31 @@
+using MassTransit;
+using Roster.Core.Events;
+using Roster.DiscordService.Configurations;
+
+namespace Roster.DiscordService
+{
+    public class MemberPromotedConsumer : IConsumer<MemberPromoted>
+    {
+        readonly ILogger<MemberPromotedConsumer> _logger;
+
+        readonly DiscordOptions _options;
+
+        private DiscordService _service;
+
+        public MemberPromotedConsumer(DiscordOptions options, ILogger<MemberPromotedConsumer> logger, DiscordService discord)
+        {
+            _logger = logger;
+            _options = options;
+            _service = discord;
+        }
+
+        public async Task Consume(ConsumeContext<MemberPromoted> context)
+        {
+            _logger.LogInformation("Received event {@event}", context.Message);
+
+            UpdateMemberRankCommand updateRankCommand = new(context.Message.DiscordId, context.Message.OldRankId, context.Message.RankId);
+
+            await _service.UpdateMemberRank(updateRankCommand);
+        }
+    }
+}

--- a/src/Roster.DiscordService/Program.cs
+++ b/src/Roster.DiscordService/Program.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.Design.Serialization;
+using Roster.DiscordService;
+using MassTransit;
+using Serilog;
+using Microsoft.Extensions.Configuration;
+using Roster.DiscordService.Configurations;
+
+Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()
+                .CreateLogger();
+
+Microsoft.Extensions.Hosting.IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+        services.AddMassTransit(x =>
+        {
+            IConfiguration configuration = hostContext.Configuration;
+
+            services.AddSingleton(configuration.GetSection("DiscordOptions").Get<DiscordOptions>());
+
+            services.AddScoped<DiscordService>();
+
+            x.AddDelayedMessageScheduler();
+
+            x.UsingRabbitMq((context, configurator) =>
+            {
+                configurator.UseDelayedMessageScheduler();
+
+                configurator.Host("localhost", "/", h =>
+                {
+                    h.Username("guest");
+                    h.Password("guest");
+                });
+
+                configurator.ConfigureEndpoints(context);
+            });
+
+            // Add consumers
+            x.AddConsumer<MemberPromotedConsumer>();
+        });
+
+        services.AddMassTransitHostedService();
+    })
+    .UseSerilog()
+    .Build();
+
+await host.RunAsync();

--- a/src/Roster.DiscordService/Properties/launchSettings.json
+++ b/src/Roster.DiscordService/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "Roster.DiscordService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Roster.DiscordService/README.md
+++ b/src/Roster.DiscordService/README.md
@@ -1,0 +1,30 @@
+# Discord Automation Service
+
+This module handles Rooster events that require actions on the community's Discord Guild (a.k.a. Discord server). 
+
+## Consumers
+
+ - `MemberPromotedConsumer` updates Discord user tags whenever a new rank is issued to a community member. Consumes `Roster.Core.Events.MemberPromoted`.
+
+## Configuration
+
+ 1. Configure the `DiscordOptions` parameters in `appsettings.json` with CNTO Discord Guild details. If you are unsure where to get the values from, check the notes section below. The sub-section `RanksMap` defines the mapping between rank identifiers in Roster and Discord respectively, using Roster ids as keys (under quotes before the comma) and Discord ids as values (after the comma). Refer to the snippet below for adjusting the configuration.
+```json
+"RanksMap": {
+      "1": 925448093170815056,  <-- Recruit
+      "2": 925448134446944287,  <-- Grunt
+      "3": 925448093170815056,  <-- Reservist
+      "4": 925448047121559603,  <-- Specialist
+      "5": 925448012283658271,  <-- Corporal
+      "6": 925447916674506832   <-- Staff Sergeant
+    }
+```
+
+ 2. The parameter `BotToken` should be passed as environment variable, i.e.
+```bash
+export DiscordOptions__BotToken="<bot_token_here>"
+```
+
+### Notes
+
+If you don't know where to find the parameters to update in the `appsettings.json`, have a look [here](https://github.com/manix84/discord_gmod_addon_v2/wiki/Finding-your-Guild-ID-%28Server-ID%29) for how to get the Guild id. Once the Developer mode is enabled you can navigate to the Roles management page to get the ranks ids as well.

--- a/src/Roster.DiscordService/Roster.DiscordService.csproj
+++ b/src/Roster.DiscordService/Roster.DiscordService.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-Roster.DiscordService-98DF5698-661C-4C55-A530-1E329CFA66A5</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Discord.Net" Version="3.1.0" />
+    <PackageReference Include="MassTransit" Version="7.3.0" />
+    <PackageReference Include="MassTransit.AspNetCore" Version="7.3.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="7.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Roster.Core.Events\Roster.Core.Events.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Roster.DiscordService/UpdateMemberRankCommand.cs
+++ b/src/Roster.DiscordService/UpdateMemberRankCommand.cs
@@ -1,0 +1,18 @@
+namespace Roster.DiscordService
+{
+    public class UpdateMemberRankCommand
+    {
+        public string DiscordNickname { get; }
+
+        public int? OldRank { get; }
+
+        public int NewRank { get; }
+
+        public UpdateMemberRankCommand(string discordNickname, int? oldRank, int newRank)
+        {
+            DiscordNickname = discordNickname;
+            OldRank = oldRank;
+            NewRank = newRank;
+        }
+    }
+}

--- a/src/Roster.DiscordService/appsettings.json
+++ b/src/Roster.DiscordService/appsettings.json
@@ -1,0 +1,20 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "DiscordOptions": {
+    "BotToken": "<Bot Token>",
+    "GuildId": 824571634391318529,
+    "RanksMap": {
+      "1": 925448093170815056,
+      "2": 925448134446944287,
+      "3": 925448093170815056,
+      "4": 925448047121559603,
+      "5": 925448012283658271,
+      "6": 925447916674506832
+    }
+  }
+}


### PR DESCRIPTION
This introduces a new `Roster.Core.Events.MemberPromoted` event consumer that connects to the
community Discord server through Discord's REST API and reflects the changes made on Roster,
by changing a member's role with the new one and removing the old role if necessary.

 - Added `MemberPromotedConsumer` that connects with MassTransit bus and consumes `MemberPromoted` events (closes #89)
 - Added `DiscordService` class to handle connection with Discord API (closes #90) and provide high-level methods for
   consumer (closes #92, closes #93, closes #94, closes #95)
 - Added `DiscordOptions` section in `appsettings.json` to map community-specific values (closes #91)