### PR TITLE
Use `docker-compose` for production and development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,40 @@
+# Rooster docker-compose stub environment file.
+# All the environment variables for the docker-compose.yml should be stored here
+# in order to avoid committing sensitive information to the repository and
+# allow for different configurations in production and development environments.
+
+# ---				NOTE						---
+# This is a stub file, all credentials and connection strings should be replaced
+# with actual values. Do not fill in this file, instead make a `.env.XYZ` file 
+# and fill the values in the new one to keep environments separated. Lastly, pass 
+# the correct env file to docker-compose with the --env-file flag.
+
+# - Infrastructure parameters
+
+ROOSTER_IMAGE_TAG=0.5.0
+
+# - Application parameters
+
+# -- RabbitMQ configuration
+RABBITMQ_HOST=roster-rabbitmq
+RABBITMQ_USERNAME=<USERNAME>
+RABBITMQ_PASSWORD=<PASSWRD>
+
+# -- Database configuration
+CONNECTION_STRINGS_ROSTER=Host=<HOST>;Port=<PORT>;Database=roster;Username=<USERNAME>;Password=<PASSWORD>
+CONNECTION_STRINGS_POSTGRES=Host=<HOST>;Port=<PORT>;Database=identity;Username=<USERNAME>;Password=<PASSWORD>
+
+# -- MailJet configuration
+MAILJET_BASE_URL=https://rooster.carpenoctem.co
+MAILJET_KEY=<KEY>
+MAILJET_SECRET=<SECRET>
+MAILJET_FROM_EMAIL=carpenoctem.arma@gmail.com
+MAILJET_FROM_NAME=Carpe Noctem Tactical Operations
+MAILJET_SUBJECT_VERIFY_ACCOUNT=Verify your e-mail
+
+# -- Rooster configuration - section for application specific parameters
+RECRUITMENT_WINDOW_DAYS=60
+RECRUITMENT_MOD_ASSESSMENT_DAYS=14
+RECRUITMENT_MINIMAL_ATTENDANCE=2
+RECRUITMENT_ONECLICK_ASSESSMENT=true
+

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,35 @@
+# Rooster docker-compose environment file.
+# All the environment variables for the docker-compose.yml should be stored here
+# in order to avoid committing sensitive information to the repository and
+# allow for different configurations in production and development environments.
+
+# - Infrastructure parameters
+
+ROOSTER_IMAGE_TAG=0.5.0
+ROOSTER_DB_IMAGE_TAG=0.5.0-snapshot
+
+# - Application parameters
+
+# -- RabbitMQ configuration
+RABBITMQ_HOST=roster-rabbitmq
+RABBITMQ_USERNAME=guest
+RABBITMQ_PASSWORD=guest
+
+# -- Database configuration
+CONNECTION_STRINGS_ROSTER=Host=postgres-dev;Port=5432;Database=roster;Username=postgres;Password=cnto_dev
+CONNECTION_STRINGS_POSTGRES=Host=postgres-dev;Port=5432;Database=identity;Username=postgres;Password=cnto_dev
+
+# -- MailJet configuration
+MAILJET_BASE_URL=http://localhost:8902
+MAILJET_KEY=<KEY>
+MAILJET_SECRET=<SECRET>
+MAILJET_FROM_EMAIL=carpenoctem.arma@gmail.com
+MAILJET_FROM_NAME=Carpe Noctem Tactical Operations
+MAILJET_SUBJECT_VERIFY_ACCOUNT=Verify your e-mail
+
+# -- Rooster configuration - section for application specific parameters
+RECRUITMENT_WINDOW_DAYS=60
+RECRUITMENT_MOD_ASSESSMENT_DAYS=14
+RECRUITMENT_MINIMAL_ATTENDANCE=2
+RECRUITMENT_ONECLICK_ASSESSMENT=true
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ resharper.xml
 
 
 .fake
+
+# Production environment configuration
+.env.prod

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 CNTO Tool for member management.
 
+## Getting started
+
+Use `docker-compose` to start both the production and development environment. For both envs a compose file is available in the repository alongisde with a `.env` stub configuration and `.env.dev` for development scenario.
+
+### Development
+
+The development environment defines the application container, message broker and database. To use it, run
+
+`docker-compose -f docker-compose.dev.yml --env-file .env.dev up -d`
+
+All the configuration parameters are contained in the `.env.dev`.
+
+### Production
+
+The production environment only defines application and message broker, as it is recommended to run database on bare metal. To deploy, make a copy of `.env` named `.env.prod` and fill in the `<VALUE>` placeholders with actual values then run:
+
+`docker-compose --env-file .env.prod up -d`
+
+For more details on how to run Rooster, [checkout the Wiki](https://github.com/CntoDev/rooster/wiki/Getting-started).
+
 ## Contributing
 
 - Branch `master` is for production-ready code and cannot be pushed to. Open a PR and code will be merged into `master` once it's approved.

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -7,7 +7,7 @@ fi
 
 mkdir docker-build
 
-CNTO_ROSTER_VERSION="0.5.0-snapshot"
+CNTO_ROSTER_VERSION="0.5.0"
 CNTO_ROSTER_CONTAINER=$(sudo docker ps -f name=cnto-arma --format '{{.Names}}')
 
 if [[ -n "$CNTO_ROSTER_CONTAINER" ]]; then

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,50 @@
+# Development environment description
+
+version: '3.3'
+services:
+    roster:
+        container_name: cnto-roster
+        ports:
+            - '8902:80'
+        depends_on:
+            - "rabbitmq"
+            - "postgres"
+        environment:
+            - RabbitMq__Host=${RABBITMQ_HOST}
+            - RabbitMq__Username=${RABBITMQ_USERNAME}
+            - RabbitMq__Password=${RABBITMQ_PASSWORD}
+            - ConnectionStrings__Roster=${CONNECTION_STRINGS_ROSTER}
+            - ConnectionStrings__PostgresConnection=${CONNECTION_STRINGS_POSTGRES}
+            - MailJet__BaseUrl=${MAILJET_BASE_URL}
+            - MailJet__Key=${MAILJET_KEY}
+            - MailJet__Secret=${MAILJET_SECRET}
+            - MailJet__FromEmail=${MAILJET_FROM_EMAIL}
+            - MailJet__FromName=${MAILJET_FROM_NAME}
+            - MailJet__Subject=${MAILJET_SUBJECT_VERIFY_ACCOUNT}
+            - Recruitment__RecruitmentWindowDays=${RECRUITMENT_WINDOW_DAYS}
+            - Recruitment__ModsAssesmentWindowDays=${RECRUITMENT_MOD_ASSESSMENT_DAYS}
+            - Recruitment__MinimalAttendance=${RECRUITMENT_MINIMAL_ATTENDANCE}
+            - Recruitment__OneClickAssessment=${RECRUITMENT_ONECLICK_ASSESSMENT}
+            - ASPNETCORE_ENVIRONMENT=Development
+        restart: always
+        image: 'cntoarma/rooster:${ROOSTER_IMAGE_TAG}'
+    rabbitmq:
+        container_name: roster-rabbitmq
+        ports:
+            - '15672:15672'
+        restart: always
+        image: 'masstransit/rabbitmq:3.9.7'
+        volumes:
+            - rabbitmq-volume:/var/lib/rabbitmq
+    postgres:
+        container_name: postgres-dev
+        ports:
+            - "5432:5432"
+        restart: always
+        image: 'cntoarma/rooster-db:${ROOSTER_DB_IMAGE_TAG}'
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_PASSWORD=cnto_dev
+
+volumes:
+    rabbitmq-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+# Production environment description
+
+version: '3.3'
+services:
+    roster:
+        container_name: cnto-roster
+        ports:
+            - '8902:80'
+        depends_on:
+            - "rabbitmq"
+        environment:
+            - RabbitMq__Host=${RABBITMQ_HOST}
+            - RabbitMq__Username=${RABBITMQ_USERNAME}
+            - RabbitMq__Password=${RABBITMQ_PASSWORD}
+            - ConnectionStrings__Roster=${CONNECTION_STRINGS_ROSTER}
+            - ConnectionStrings__PostgresConnection=${CONNECTION_STRINGS_POSTGRES}
+            - MailJet__BaseUrl=${MAILJET_BASE_URL}
+            - MailJet__Key=${MAILJET_KEY}
+            - MailJet__Secret=${MAILJET_SECRET}
+            - MailJet__FromEmail=${MAILJET_FROM_EMAIL}
+            - MailJet__FromName=${MAILJET_FROM_NAME}
+            - MailJet__Subject=${MAILJET_SUBJECT_VERIFY_ACCOUNT}
+            - Recruitment__RecruitmentWindowDays=${RECRUITMENT_WINDOW_DAYS}
+            - Recruitment__ModsAssesmentWindowDays=${RECRUITMENT_MOD_ASSESSMENT_DAYS}
+            - Recruitment__MinimalAttendance=${RECRUITMENT_MINIMAL_ATTENDANCE}
+            - Recruitment__OneClickAssessment=${RECRUITMENT_ONECLICK_ASSESSMENT}
+        restart: always
+        image: 'cntoarma/rooster:${ROOSTER_IMAGE_TAG}'
+    rabbitmq:
+        container_name: roster-rabbitmq
+        ports:
+            - '15672:15672'
+        restart: always
+        image: 'masstransit/rabbitmq:3.9.7'
+        volumes:
+            - rabbitmq-volume:/var/lib/rabbitmq
+
+volumes:
+    rabbitmq-volume:


### PR DESCRIPTION
Added docker-compose files for production and development environments and moved each env configuration into `.dev` files to keep secrets, well, secret as well as improve flexibility.